### PR TITLE
fix:staled transactions will lead to oom if the pool is always not-empty

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1902,6 +1902,7 @@ func (pool *LegacyPool) demoteUnexecutables(demoteAddrs []common.Address) {
 	}
 	demoteTxMeter.Mark(int64(len(demoteAddrs)))
 
+	var removed = 0
 	// Iterate over all accounts and demote any non-executable transactions
 	gasLimit := txpool.EffectiveGasLimit(pool.chainconfig, pool.currentHead.Load().GasLimit, pool.config.EffectiveGasCeil)
 	for _, addr := range demoteAddrs {
@@ -1965,7 +1966,9 @@ func (pool *LegacyPool) demoteUnexecutables(demoteAddrs []common.Address) {
 			}
 		}
 		pool.pendingCache.del(dropPendingCache, pool.signer)
+		removed += len(dropPendingCache)
 	}
+	pool.priced.Removed(removed)
 }
 
 // addressByHeartbeat is an account address tagged with its last activity timestamp.


### PR DESCRIPTION
### Description

fix:staled transactions will lead to oom if the pool is always not-empty
